### PR TITLE
New callback 'onAngleChangedPanEnd'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.9
+- added onAngleChangedPanEnd callback
+
 ## 0.0.8
 - fixed code formatting
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ RotatableOverlay(
 | `snapCurve` | Determines the animation curve to the nearest snap angle |
 | `onSnap` | Callback that is called when the rotation snaps |
 | `onAngleChanged` | Callback that is called when the angle of the rotation changes |
+| `onAngleChangedPanEnd` | Callback that is called when the pan gesture ends |
 | `onSnapAnimationEnd` | Callback that is called when animation to the nearest snap angle is finished |
 
 ### Example

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -35,6 +35,9 @@ class RotatableOverlay extends StatefulWidget {
 
   /// Callback that is called when the angle of the rotation changes.
   final void Function(Angle)? onAngleChanged;
+  
+  /// Callback that is called when the pan gesture ends
+  final void Function(Angle)? onAngleChangedPanEnd;
 
   /// Callback that is called when animation to the nearest snap angle is finished.
   final VoidCallback? onSnapAnimationEnd;
@@ -50,6 +53,7 @@ class RotatableOverlay extends StatefulWidget {
     this.initialRotation,
     this.onSnap,
     this.onAngleChanged,
+    this.onAngleChangedPanEnd,
     this.onSnapAnimationEnd,
     required this.child,
   }) : assert(
@@ -241,5 +245,6 @@ class _RotatableOverlayState extends State<RotatableOverlay>
       _controller.animateTo(snap.radians,
           duration: duration, curve: widget.snapCurve);
     }
+    widget.onAngleChangedPanEnd?.call(_childAngle);
   }
 }

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -27,7 +27,7 @@ class RotatableOverlay extends StatefulWidget {
   /// Whether the duration of the snap animation is constant or it should be calculated based on the relative angle it has to rotate
   final bool shouldUseRelativeSnapDuration;
 
-  /// Determines the animation curve to the nearest snap angle
+  /// Determines the animation curve to the nearest snap angle.
   final Curve snapCurve;
 
   /// Callback that is called when the rotation snaps.
@@ -36,7 +36,7 @@ class RotatableOverlay extends StatefulWidget {
   /// Callback that is called when the angle of the rotation changes.
   final void Function(Angle)? onAngleChanged;
   
-  /// Callback that is called when the pan gesture ends
+  /// Callback that is called when the pan gesture ends.
   final void Function(Angle, Angle?)? onAngleChangedPanEnd;
 
   /// Callback that is called when animation to the nearest snap angle is finished.
@@ -209,7 +209,7 @@ class _RotatableOverlayState extends State<RotatableOverlay>
 
     if (newChildAngleSnapped != null &&
         newChildAngleSnapped != _childAngleSnapped) {
-      // Angle is ocvered by a snap range and the snap angle
+      // Angle is covered by a snap range and the snap angle
       // differs from previous one
       widget.onSnap?.call(newChildAngleSnapped);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rotatable_overlay
 description: A flutter widget that makes its child rotatable by dragging around its center
-version: 0.0.8
+version: 0.0.9
 repository: https://github.com/daniel-riffi/rotatable_overlay
 
 environment:


### PR DESCRIPTION
Hi,

Thanks for your code. It works great.

In my application, I needed a callback, which (a) gives me the angle after the pan motion ended and  (b) also provides the snap angle, in particular, when the valid range is limited (e.g., 0-90 deg). Not sure whether this is the best approach, but anyway, maybe it's useful.

Cheers