### PR TITLE
Adding Inertia to RotatableOverlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ RotatableOverlay(
 | `onAngleChanged` | Callback that is called when the angle of the rotation changes |
 | `onAngleChangedPanEnd` | Callback that is called when the pan gesture ends |
 | `onSnapAnimationEnd` | Callback that is called when animation to the nearest snap angle is finished |
+| `applyInertia` | Whether to add inertia to the movement when stopped dragging |
+| `frictionCoefficient` | The friction coefficient to apply to inertia. |
 
 ### Example
 
@@ -56,6 +58,55 @@ class App extends StatelessWidget {
               snapDelta: Angle.degrees(5),
               shouldSnapOnEnd: true,
               shouldUseRelativeSnapDuration: true,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  Container(
+                    height: 150,
+                    width: 150,
+                    color: Colors.green,
+                  ),
+                  const Positioned(
+                    top: 0,
+                    child: Text('N', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                  ),
+                  const Positioned(
+                    right: 0,
+                    child: Text('E', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                  ),
+                  const Positioned(
+                    left: 0,
+                    child: Text('W', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                  ),
+                  const Positioned(
+                    bottom: 0,
+                    child: Text('S', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+#### Using inertia:
+```dart
+class App extends StatelessWidget {
+  const App({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        body: SafeArea(
+          child: Center(
+            child: RotatableOverlay(
+              applyInertia: true,
               child: Stack(
                 alignment: Alignment.center,
                 children: [

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ RotatableOverlay(
 | `onSnapAnimationEnd` | Callback that is called when animation to the nearest snap angle is finished |
 | `applyInertia` | Whether to add inertia to the movement when stopped dragging |
 | `frictionCoefficient` | The friction coefficient to apply to inertia. |
+| `limitDragToBounds` | Wether to limit drag to widget bounds (increase robustness of rotation sign determination) |
 
 ### Example
 
@@ -107,6 +108,7 @@ class App extends StatelessWidget {
           child: Center(
             child: RotatableOverlay(
               applyInertia: true,
+              limitDragToBounds: true,
               child: Stack(
                 alignment: Alignment.center,
                 children: [

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -96,6 +96,8 @@ class _RotatableOverlayState extends State<RotatableOverlay>
 
   Offset _centerOfChild = Offset.zero;
 
+  bool startingAnimation = true;
+
   @override
   void initState() {
     _controller = AnimationController.unbounded(
@@ -202,6 +204,7 @@ class _RotatableOverlayState extends State<RotatableOverlay>
   void _onPanStart(DragStartDetails details) {
     // Stop any ongoing animations to prevent conflicts
     _controller.stop();
+    startingAnimation = true;
 
     var dy = details.globalPosition.dy - _centerOfChild.dy;
     var dx = details.globalPosition.dx - _centerOfChild.dx;
@@ -222,14 +225,18 @@ class _RotatableOverlayState extends State<RotatableOverlay>
       }
     }
 
-    // Calculate the current and previous pointer positions relative to the center
-    var currentVector = details.globalPosition - _centerOfChild;
-    var previousVector = Offset.fromDirection(_mouseAngle.radians);
-    var crossProduct = (previousVector.dx * currentVector.dy) -
-        (previousVector.dy * currentVector.dx);
-    // Determine the sign of rotation based on the cross product
-    isRotationClockwise =
-        crossProduct > 0 ? true : (crossProduct < 0 ? false : null);
+    if (startingAnimation) {
+      // Calculate the current and previous pointer positions relative to the center
+      var currentVector = details.globalPosition - _centerOfChild;
+      var previousVector = Offset.fromDirection(_mouseAngle.radians);
+      var crossProduct = (previousVector.dx * currentVector.dy) -
+          (previousVector.dy * currentVector.dx);
+      // Determine the sign of rotation based on the cross product
+      isRotationClockwise =
+          crossProduct > 0 ? true : (crossProduct < 0 ? false : null);
+
+      startingAnimation = false;
+    }
 
     var dy = details.globalPosition.dy - _centerOfChild.dy;
     var dx = details.globalPosition.dx - _centerOfChild.dx;

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -193,6 +193,35 @@ class _RotatableOverlayState extends State<RotatableOverlay>
   }
 
   void _onPanUpdate(DragUpdateDetails details) {
+    // Get the RenderBox of the parent widget to calculate bounds
+    final parentBox = context.findRenderObject() as RenderBox;
+    final parentPosition = parentBox.localToGlobal(Offset.zero);
+    final parentSize = parentBox.size;
+
+    // Calculate the bounds of the parent widget
+    final parentBounds = Rect.fromLTWH(
+      parentPosition.dx,
+      parentPosition.dy,
+      parentSize.width,
+      parentSize.height,
+    );
+
+    // Check if the pointer is within the bounds
+    if (!parentBounds.contains(details.globalPosition)) {
+      return; // Ignore updates if the pointer is outside the parent's bounds
+    }
+
+    // Calculate the current and previous pointer positions relative to the center
+    var currentVector = details.globalPosition - _centerOfChild;
+    var previousVector = Offset.fromDirection(_mouseAngle.radians);
+
+    // Calculate the cross product to determine the rotation direction
+    var crossProduct = (previousVector.dx * currentVector.dy) -
+        (previousVector.dy * currentVector.dx);
+
+    // Determine the sign of rotation based on the cross product
+    var signOfRotation = crossProduct > 0 ? 1 : (crossProduct < 0 ? -1 : 0);
+
     var dy = details.globalPosition.dy - _centerOfChild.dy;
     var dx = details.globalPosition.dx - _centerOfChild.dx;
 

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -263,16 +263,12 @@ class _RotatableOverlayState extends State<RotatableOverlay>
   }
 
   void _onPanEnd(DragEndDetails details) {
-    // Check if we should apply inertia
     if (widget.applyInertia) {
-      // Avoid division by zero
-
-      // Start inertia animation with the calculated angular velocity
       _startInertiaAnimation(isRotationClockwise!
           ? -details.velocity.pixelsPerSecond.distance / 100
           : details.velocity.pixelsPerSecond.distance / 100);
     }
-    
+
     Angle? snap;
     if (widget.shouldSnapOnEnd && !_snaps.contains(_childAngleSnapped)) {
       // Pan gesture ended and we snap, but _childAngleSnapped is null,

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -25,7 +25,7 @@ class RotatableOverlay extends StatefulWidget {
   /// If [shouldUseRelativeSnapDuration] is true, [snapDuration] determines how long the animation takes for 360 degrees.
   final Duration snapDuration;
 
-  /// Whether the duration of the snap animation is constant or it should be calculated based on the relative angle it has to rotate
+  /// Whether the duration of the snap animation is constant or it should be calculated based on the relative angle it has to rotate.
   final bool shouldUseRelativeSnapDuration;
 
   /// Determines the animation curve to the nearest snap angle.
@@ -49,7 +49,7 @@ class RotatableOverlay extends StatefulWidget {
   /// The friction coefficient to apply to inertia.
   final double frictionCoefficient;
 
-  /// Wether to limit drag to widget bounds (increase robustness of rotation sign determination)
+  /// Whether to limit drag to widget bounds (increase robustness of rotation sign determination).
   final bool limitDragToBounds;
   RotatableOverlay({
     super.key,
@@ -92,19 +92,15 @@ class _RotatableOverlayState extends State<RotatableOverlay>
 
   late bool? isRotationClockwise;
 
-  late final AnimationController _controller = widget.applyInertia
-      ? AnimationController.unbounded(
-          vsync: this,
-        )
-      : AnimationController(
-          vsync: this,
-          upperBound: 4 * math.pi,
-        );
+  late final AnimationController _controller;
 
   Offset _centerOfChild = Offset.zero;
 
   @override
   void initState() {
+    _controller = AnimationController.unbounded(
+      vsync: this,
+    );
     _childAngle = widget.initialRotation ?? Angle.zero();
     _childAngleSnapped = widget.initialRotation;
     _lastChangeAngle = _childAngle;

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -257,7 +257,6 @@ class _RotatableOverlayState extends State<RotatableOverlay>
   }
 
   void _onPanEnd(DragEndDetails details) {
-    Angle? snap;
     // Check if we should apply inertia
     if (widget.applyInertia) {
       // Avoid division by zero
@@ -270,6 +269,7 @@ class _RotatableOverlayState extends State<RotatableOverlay>
     if (widget.shouldSnapOnEnd && !_snaps.contains(_childAngleSnapped)) {
       // Pan gesture ended and we snap, but _childAngleSnapped is null,
       // because current rotation is outside all defined snap ranges.
+      Angle? snap;
       snap = _childAngle.getClosest(_snaps);
 
       if ((_childAngle - snap).abs() > Angle.half()) {

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -200,6 +200,9 @@ class _RotatableOverlayState extends State<RotatableOverlay>
   }
 
   void _onPanStart(DragStartDetails details) {
+    // Stop any ongoing animations to prevent conflicts
+    _controller.stop();
+
     var dy = details.globalPosition.dy - _centerOfChild.dy;
     var dx = details.globalPosition.dx - _centerOfChild.dx;
     var newMouseAngle = Angle.atan2(dy, dx);

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -272,10 +272,12 @@ class _RotatableOverlayState extends State<RotatableOverlay>
           ? -details.velocity.pixelsPerSecond.distance / 100
           : details.velocity.pixelsPerSecond.distance / 100);
     }
+    
+    Angle? snap;
     if (widget.shouldSnapOnEnd && !_snaps.contains(_childAngleSnapped)) {
       // Pan gesture ended and we snap, but _childAngleSnapped is null,
       // because current rotation is outside all defined snap ranges.
-      Angle? snap;
+
       snap = _childAngle.getClosest(_snaps);
 
       if ((_childAngle - snap).abs() > Angle.half()) {

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -36,7 +36,7 @@ class RotatableOverlay extends StatefulWidget {
 
   /// Callback that is called when the angle of the rotation changes.
   final void Function(Angle)? onAngleChanged;
-  
+
   /// Callback that is called when the pan gesture ends.
   final void Function(Angle, Angle?)? onAngleChangedPanEnd;
 
@@ -48,6 +48,9 @@ class RotatableOverlay extends StatefulWidget {
 
   /// The friction coefficient to apply to inertia.
   final double frictionCoefficient;
+
+  /// Wether to limit drag to widget bounds (increase robustness of rotation sign determination)
+  final bool limitDragToBounds;
   RotatableOverlay({
     super.key,
     this.snaps,
@@ -63,6 +66,7 @@ class RotatableOverlay extends StatefulWidget {
     this.onSnapAnimationEnd,
     this.applyInertia = false,
     this.frictionCoefficient = 0.1,
+    this.limitDragToBounds = false,
     required this.child,
   }) : assert(
             shouldSnapOnEnd && (snaps?.isNotEmpty ?? false) || !shouldSnapOnEnd,
@@ -209,12 +213,14 @@ class _RotatableOverlayState extends State<RotatableOverlay>
   }
 
   void _onPanUpdate(DragUpdateDetails details) {
-    // Ignore updates if the pointer is outside the widget's bounds
-    final size = context.size;
-    if (size == null) return;
-    final bounds = Offset.zero & size;
-    if (!bounds.contains(details.localPosition)) {
-      return;
+    if (widget.limitDragToBounds) {
+      // Ignore updates if the pointer is outside the widget's bounds
+      final size = context.size;
+      if (size == null) return;
+      final bounds = Offset.zero & size;
+      if (!bounds.contains(details.localPosition)) {
+        return;
+      }
     }
 
     // Calculate the current and previous pointer positions relative to the center

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -260,9 +260,12 @@ class _RotatableOverlayState extends State<RotatableOverlay>
 
   void _onPanEnd(DragEndDetails details) {
     if (widget.applyInertia) {
-      _startInertiaAnimation(isRotationClockwise!
+      final rotationDirection =
+          isRotationClockwise ?? true; // Default to true if null
+      final velocity = rotationDirection
           ? -details.velocity.pixelsPerSecond.distance / 100
-          : details.velocity.pixelsPerSecond.distance / 100);
+          : details.velocity.pixelsPerSecond.distance / 100;
+      _startInertiaAnimation(velocity);
     }
 
     Angle? snap;

--- a/lib/src/rotatable_overlay.dart
+++ b/lib/src/rotatable_overlay.dart
@@ -143,20 +143,6 @@ class _RotatableOverlayState extends State<RotatableOverlay>
     super.initState();
   }
 
-  void _startInertiaAnimation(double velocity) {
-    _controller.stop();
-
-    // Create a friction simulation with the current angle and velocity
-    final simulation = FrictionSimulation(
-      widget.frictionCoefficient,
-      _childAngle.radians,
-      velocity,
-    );
-
-    // Animate using the simulation
-    _controller.animateWith(simulation);
-  }
-
   @override
   void didUpdateWidget(covariant RotatableOverlay oldWidget) {
     if (oldWidget.initialRotation != widget.initialRotation) {
@@ -234,7 +220,6 @@ class _RotatableOverlayState extends State<RotatableOverlay>
     // Calculate the current and previous pointer positions relative to the center
     var currentVector = details.globalPosition - _centerOfChild;
     var previousVector = Offset.fromDirection(_mouseAngle.radians);
-    // Calculate the cross product to determine the rotation direction
     var crossProduct = (previousVector.dx * currentVector.dy) -
         (previousVector.dy * currentVector.dx);
     // Determine the sign of rotation based on the cross product
@@ -312,5 +297,19 @@ class _RotatableOverlayState extends State<RotatableOverlay>
     }
     // Callback providing current rotation angle and snap angle
     widget.onAngleChangedPanEnd?.call(_childAngle, snap);
+  }
+
+  void _startInertiaAnimation(double velocity) {
+    _controller.stop();
+
+    // Create a friction simulation with the current angle and velocity
+    final simulation = FrictionSimulation(
+      widget.frictionCoefficient,
+      _childAngle.radians,
+      velocity,
+    );
+
+    // Animate using the simulation
+    _controller.animateWith(simulation);
   }
 }


### PR DESCRIPTION
Great job!

For my application, I needed the rotation to be more natural and to continue with inertia when the drag was stopped. In fact, I needed a vinyl image that could be scratched like a real one.

I added 2 parameters to RotatableOverlay:

- **applyInertia**: A boolean parameter that enables inertia when set to true. The widget will continue rotating with decreasing speed after the user stops dragging.

- **frictionCoefficient**: A double parameter that determines the rate at which the rotation slows down. Lower values result in quicker deceleration.


Implementation Details:

- **Inertia Simulation:** Utilizes FrictionSimulation to mimic the effect of inertia. When the drag ends, the simulation starts with the current velocity and gradually reduces it based on the friction coefficient.
- **Rotation Direction:** Determines the direction of rotation (clockwise or counterclockwise) using the cross product of the current and previous pointer positions relative to the widget’s center. 
- Widget Bounds Limitation: Improves the accuracy of rotation direction direction determination by limiting pan updates to the widget’s bounds.
- Interaction with Snaps:
1. When applyInertia is set to true, snap angles are ignored to allow smooth inertia.
2. If snap functionality is required, set applyInertia to false.
